### PR TITLE
increase min qts version

### DIFF
--- a/qpkg.cfg
+++ b/qpkg.cfg
@@ -56,7 +56,7 @@ QPKG_HEALTHY_CHECK_CMD="./owncloud.sh ready-check"
 #QPKG_DESKTOP_APP_WIN_HEIGHT=""
 
 # Minimum QTS version requirement
-QTS_MINI_VERSION="4.1.0"
+QTS_MINI_VERSION="4.5.4"
 # Maximum QTS version requirement
 QTS_MAX_VERSION="6.0.0"
 


### PR DESCRIPTION
increase the minimum QTS version because on prior QTS versions our signed QPKGs will not be recognized as signed.